### PR TITLE
Removing android:permission causing failure on old android version

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -17,8 +17,7 @@
         android:theme="@style/AppTheme" >
         <activity
             android:name="com.app.product_open_data.MainActivity"
-            android:label="@string/app_name"
-            android:permission="android.permission.INTERNET" >
+            android:label="@string/app_name" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 


### PR DESCRIPTION
Fixing the bug on my device for android:permission Activity in the Manifest.
